### PR TITLE
Add Next.js frontend and converter job images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Node
+node_modules/
+.npm
+
+# Next.js
+.next/
+
+# Python
+__pycache__/
+*.pyc
+
+# Mac
+.DS_Store
+
+# Env files
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -1,11 +1,92 @@
-# videotogif
+# Video to GIF demo
 
-This project is for a demo of Huawei Cloud's CCE and CCI. 
+This repository contains a sample application to demonstrate how Huawei Cloud's **Cloud Container Engine (CCE)** and **Cloud Container Instance (CCI)** can work together. Two container images are provided:
 
-There are going to be two container images, one for the frontend server of this application and another for the jobs that are going to be used
+1. **Frontend (CCE)** – a Next.js application that receives video uploads, stores them in Object Storage (OBS), and dispatches conversion jobs to CCI.
+2. **Converter job (CCI)** – a Python worker that downloads the uploaded video from OBS, converts it to GIF with `ffmpeg`, uploads the result back to OBS, and notifies the frontend once the conversion finishes.
 
-The application is going to be a server that recieves video files and convert them to gifs, saves them, and them returns the link for download
+## Repository structure
 
-The frontend is going to be made using Next.js and the image will be deployed in CCE
+```text
+frontend/   # Next.js application packaged for CCE
+converter/  # Python + ffmpeg job image to run on CCI
+```
 
-The converter part is going to run on CCI as jobs and it will recieve the video, will convert it using ffmpeg, will save the result to OBS and will return a link to download to the frontend
+## Frontend overview
+
+The frontend exposes two API routes:
+
+- `POST /api/jobs` accepts a video file upload, stores the video in OBS, records the request locally, and calls the `CCI_JOB_WEBHOOK` endpoint to trigger a conversion job.
+- `POST /api/job-status` is used by the converter job to update the status of a conversion. On success it stores the generated download URL so it can be surfaced to the UI.
+
+An in-memory store (`frontend/server/jobStore.ts`) keeps a short-lived history of jobs for demo purposes. For production deployments you should replace this with a persistent database.
+
+### Environment variables
+
+Configure the following variables when deploying the frontend image:
+
+| Variable | Description |
+| --- | --- |
+| `OBS_ENDPOINT` | OBS endpoint (e.g. `https://obs.eu-west-101.myhuaweicloud.com`). |
+| `OBS_ACCESS_KEY_ID` | Access key ID for OBS. |
+| `OBS_SECRET_ACCESS_KEY` | Secret access key for OBS. |
+| `OBS_BUCKET_NAME` | OBS bucket that stores uploads and generated GIFs. |
+| `OBS_UPLOAD_PREFIX` | (Optional) Object key prefix for uploaded videos, defaults to `uploads/`. |
+| `OBS_OUTPUT_PREFIX` | (Optional) Object key prefix for generated GIFs, defaults to `gifs/`. |
+| `PUBLIC_BASE_URL` | Public URL of the frontend (used to build job callbacks). |
+| `CCI_JOB_WEBHOOK` | Endpoint that the frontend calls to trigger a converter job in CCI. |
+| `CCI_JOB_WEBHOOK_TOKEN` | (Optional) Bearer token attached to the webhook request. |
+
+## Converter job overview
+
+The converter image is a minimal Python application that runs the following steps:
+
+1. Download the original video from OBS using the provided key.
+2. Run `ffmpeg` to convert the video into an animated GIF.
+3. Upload the GIF to OBS and create a time-limited signed URL.
+4. POST the job result to the callback URL supplied by the frontend.
+
+### Required environment variables
+
+| Variable | Description |
+| --- | --- |
+| `OBS_ENDPOINT` | OBS endpoint used by the job container. |
+| `OBS_ACCESS_KEY_ID` | Access key ID for OBS. |
+| `OBS_SECRET_ACCESS_KEY` | Secret access key for OBS. |
+| `OBS_BUCKET_NAME` | OBS bucket containing inputs and outputs. |
+| `SOURCE_OBJECT_KEY` | Object key of the uploaded source video. |
+| `TARGET_OBJECT_KEY` | Object key where the GIF should be stored. |
+| `JOB_ID` | Identifier of the job (passed back to the frontend). |
+| `CALLBACK_URL` | URL in the frontend that will receive job status updates. |
+
+## Building the images
+
+```bash
+# Frontend (Next.js)
+cd frontend
+npm install
+npm run build
+docker build -t videotogif-frontend:latest .
+
+# Converter job (Python + ffmpeg)
+cd ../converter
+pip install -r requirements.txt
+python main.py  # Runs locally with the required environment variables set
+docker build -t videotogif-converter:latest .
+```
+
+When running locally, export the necessary OBS credentials and object keys before invoking the scripts.
+
+## Local development
+
+- Run `npm install` followed by `npm run dev` inside the `frontend/` directory to start the Next.js development server.
+- The frontend uses an in-memory job store. Restarting the server clears all recorded jobs.
+- The converter job can be executed locally by setting the required environment variables (for example using a `.env` file) and running `python main.py`.
+
+## Deployment notes
+
+- Deploy the `frontend` image on Huawei Cloud CCE and expose it through an ingress controller.
+- Use the `converter` image as the container template for Huawei Cloud CCI jobs. The webhook or controller that receives `POST /api/jobs` requests must populate the environment variables listed above before launching the job.
+- For observability, ensure logs from both containers are collected. The converter prints a JSON summary of the conversion result to stdout.
+
+This demo intentionally keeps the architecture simple so it can be adapted to different pipelines or integrated with additional Huawei Cloud services.

--- a/converter/.dockerignore
+++ b/converter/.dockerignore
@@ -1,0 +1,3 @@
+__pycache__
+*.pyc
+.env

--- a/converter/Dockerfile
+++ b/converter/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+ENTRYPOINT ["python", "/app/main.py"]

--- a/converter/requirements.txt
+++ b/converter/requirements.txt
@@ -1,0 +1,2 @@
+esdk-obs-python==3.23.3
+requests==2.31.0

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+npm-debug.log
+Dockerfile
+README.md
+tsconfig.json
+.eslintrc.json

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+FROM node:18-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --ignore-scripts
+
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build && npm prune --production
+
+FROM node:18-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+EXPOSE 3000
+CMD ["node", "server.js"]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone',
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "videotogif-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "esdk-obs-nodejs": "3.25.6",
+    "formidable": "3.5.1",
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "swr": "2.2.0"
+  },
+  "devDependencies": {
+    "@types/formidable": "3.4.5",
+    "@types/node": "20.11.5",
+    "@types/react": "18.2.37",
+    "@types/react-dom": "18.2.15",
+    "eslint": "8.55.0",
+    "eslint-config-next": "13.5.6",
+    "typescript": "5.3.3"
+  }
+}

--- a/frontend/pages/api/job-status.ts
+++ b/frontend/pages/api/job-status.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { updateJob } from '../../server/jobStore';
+import { createSignedUrl } from '../../server/obsClient';
+
+type JobStatus = 'pending' | 'running' | 'failed' | 'completed';
+
+function isValidStatus(status: unknown): status is JobStatus {
+  return status === 'pending' || status === 'running' || status === 'failed' || status === 'completed';
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<{ message: string }>) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  let { jobId, status, downloadUrl, errorMessage, targetKey } = req.body ?? {};
+
+  if (typeof jobId !== 'string' || !isValidStatus(status)) {
+    res.status(400).json({ message: 'jobId and a valid status are required' });
+    return;
+  }
+
+  if (status === 'completed' && !downloadUrl && typeof targetKey === 'string') {
+    try {
+      downloadUrl = createSignedUrl(targetKey);
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  try {
+    updateJob(jobId, {
+      status,
+      downloadUrl,
+      errorMessage,
+    });
+
+    res.status(200).json({ message: 'Job updated' });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Unable to update job' });
+  }
+}

--- a/frontend/pages/api/jobs.ts
+++ b/frontend/pages/api/jobs.ts
@@ -1,0 +1,106 @@
+import { randomUUID } from 'crypto';
+import { readFile, unlink } from 'fs/promises';
+import formidable from 'formidable';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { persistJob, retrieveJobs, updateJob } from '../../server/jobStore';
+import { dispatchConversionJob } from '../../server/jobDispatcher';
+import { uploadBufferToObs } from '../../server/obsClient';
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};
+
+type JobsResponse = ReturnType<typeof retrieveJobs>;
+
+async function parseForm(req: NextApiRequest) {
+  const form = formidable({ multiples: false });
+
+  return new Promise<{ filename: string; buffer: Buffer }>((resolve, reject) => {
+    form.parse(req, (err, _fields, files) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      const file = Array.isArray(files.file) ? files.file[0] : files.file;
+      if (!file || !file.filepath || !file.originalFilename) {
+        reject(new Error('File upload is required'));
+        return;
+      }
+
+      if (!file.mimetype?.startsWith('video/')) {
+        reject(new Error('Only video files are supported'));
+        return;
+      }
+
+      readFile(file.filepath)
+        .then(async (data) => {
+          await unlink(file.filepath).catch(() => undefined);
+          resolve({ filename: file.originalFilename!, buffer: data });
+        })
+        .catch(reject);
+    });
+  });
+}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<JobsResponse | { message: string }>
+) {
+  if (req.method === 'GET') {
+    const jobs = retrieveJobs();
+    res.status(200).json(jobs);
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'GET, POST');
+    res.status(405).json({ message: 'Method not allowed' });
+    return;
+  }
+
+  let jobId: string | undefined;
+
+  try {
+    const { buffer, filename } = await parseForm(req);
+
+    const timestamp = Date.now();
+    const sourceKey = `${process.env.OBS_UPLOAD_PREFIX ?? 'uploads/'}${timestamp}-${filename}`;
+    const targetKey = `${process.env.OBS_OUTPUT_PREFIX ?? 'gifs/'}${timestamp}-${filename.replace(/\.[^.]+$/, '')}.gif`;
+
+    await uploadBufferToObs(buffer, sourceKey);
+
+    jobId = randomUUID();
+
+    persistJob({
+      id: jobId,
+      status: 'pending',
+      sourceKey,
+      targetKey,
+      createdAt: timestamp,
+    });
+
+    await dispatchConversionJob({
+      jobId,
+      sourceKey,
+      targetKey,
+    });
+
+    res.status(201).json(retrieveJobs());
+  } catch (error) {
+    console.error(error);
+    const message = error instanceof Error ? error.message : 'Unable to create conversion job';
+
+    if (jobId) {
+      try {
+        updateJob(jobId, { status: 'failed', errorMessage: message });
+      } catch (storeError) {
+        console.error(storeError);
+      }
+    }
+
+    res.status(500).json({ message });
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,203 @@
+import { FormEvent, useState } from 'react';
+import useSWR from 'swr';
+
+interface ConversionJob {
+  id: string;
+  status: 'pending' | 'running' | 'failed' | 'completed';
+  sourceKey: string;
+  targetKey?: string;
+  downloadUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+}
+
+const fetcher = async (url: string) => {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Failed to fetch job state');
+  }
+  return response.json() as Promise<ConversionJob[]>;
+};
+
+export default function Home() {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { data: jobs, mutate } = useSWR<ConversionJob[]>('/api/jobs', fetcher, {
+    refreshInterval: 3000,
+  });
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedFile) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', selectedFile);
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch('/api/jobs', {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'Unable to create conversion job');
+      }
+
+      await mutate();
+      setSelectedFile(null);
+    } catch (error) {
+      console.error(error);
+      alert(error instanceof Error ? error.message : 'Unable to create job');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="container">
+      <main>
+        <h1>Video to GIF</h1>
+        <p>Upload a video and we will convert it into a shareable GIF.</p>
+
+        <form onSubmit={handleSubmit}>
+          <label className="file-input">
+            <input
+              type="file"
+              accept="video/*"
+              onChange={(event) => {
+                const file = event.target.files?.item(0) ?? null;
+                setSelectedFile(file);
+              }}
+              required
+            />
+          </label>
+          <button type="submit" disabled={isSubmitting}>
+            {isSubmitting ? 'Uploading…' : 'Create conversion job'}
+          </button>
+        </form>
+
+        <section className="jobs">
+          <h2>Recent jobs</h2>
+          {!jobs?.length && <p>No jobs yet. Upload a video to get started!</p>}
+          <ul>
+            {jobs?.map((job) => (
+              <li key={job.id}>
+                <div>
+                  <strong>{job.sourceKey}</strong>
+                  <p>Submitted: {new Date(job.createdAt).toLocaleString()}</p>
+                  <p>Status: {job.status}</p>
+                  {job.errorMessage && <p className="error">Error: {job.errorMessage}</p>}
+                  {job.downloadUrl && (
+                    <p>
+                      <a href={job.downloadUrl} target="_blank" rel="noreferrer">
+                        Download GIF
+                      </a>
+                    </p>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      </main>
+      <style jsx>{`
+        .container {
+          min-height: 100vh;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: flex-start;
+          padding: 2rem;
+          background: linear-gradient(180deg, #111827 0%, #1f2937 100%);
+          color: #f9fafb;
+          font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+
+        main {
+          width: 100%;
+          max-width: 720px;
+        }
+
+        h1 {
+          font-size: 2.5rem;
+          margin-bottom: 0.5rem;
+        }
+
+        p {
+          font-size: 1.1rem;
+          line-height: 1.6;
+        }
+
+        form {
+          margin: 2rem 0;
+          display: flex;
+          gap: 1rem;
+          flex-wrap: wrap;
+        }
+
+        .file-input {
+          flex: 1;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 1rem;
+          border: 2px dashed rgba(255, 255, 255, 0.2);
+          border-radius: 0.75rem;
+          cursor: pointer;
+          transition: border-color 0.2s ease, background 0.2s ease;
+        }
+
+        .file-input:hover {
+          border-color: rgba(255, 255, 255, 0.4);
+          background: rgba(255, 255, 255, 0.04);
+        }
+
+        .file-input input {
+          width: 100%;
+        }
+
+        button {
+          padding: 0.75rem 1.5rem;
+          background: #2563eb;
+          border: none;
+          border-radius: 0.75rem;
+          color: #f9fafb;
+          font-weight: 600;
+          cursor: pointer;
+          transition: background 0.2s ease;
+        }
+
+        button:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+
+        button:not(:disabled):hover {
+          background: #1d4ed8;
+        }
+
+        .jobs ul {
+          list-style: none;
+          padding: 0;
+          display: grid;
+          gap: 1rem;
+        }
+
+        .jobs li {
+          padding: 1rem;
+          background: rgba(17, 24, 39, 0.8);
+          border-radius: 0.75rem;
+          border: 1px solid rgba(255, 255, 255, 0.05);
+        }
+
+        .error {
+          color: #f87171;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/server/jobDispatcher.ts
+++ b/frontend/server/jobDispatcher.ts
@@ -1,0 +1,45 @@
+import { updateJob } from './jobStore';
+
+type DispatchOptions = {
+  jobId: string;
+  sourceKey: string;
+  targetKey: string;
+};
+
+const CALLBACK_PATH = '/api/job-status';
+
+export async function dispatchConversionJob(options: DispatchOptions) {
+  const endpoint = process.env.CCI_JOB_WEBHOOK;
+  if (!endpoint) {
+    throw new Error('CCI_JOB_WEBHOOK environment variable is not configured');
+  }
+
+  const payload = {
+    jobId: options.jobId,
+    sourceKey: options.sourceKey,
+    targetKey: options.targetKey,
+    callbackUrl: new URL(CALLBACK_PATH, process.env.PUBLIC_BASE_URL ?? 'http://localhost:3000').toString(),
+  };
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  const authToken = process.env.CCI_JOB_WEBHOOK_TOKEN;
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`Failed to dispatch job: ${message}`);
+  }
+
+  updateJob(options.jobId, { status: 'running' });
+}

--- a/frontend/server/jobStore.ts
+++ b/frontend/server/jobStore.ts
@@ -1,0 +1,38 @@
+export type JobRecord = {
+  id: string;
+  status: 'pending' | 'running' | 'failed' | 'completed';
+  sourceKey: string;
+  targetKey: string;
+  downloadUrl?: string;
+  errorMessage?: string;
+  createdAt: number;
+};
+
+const jobs = new Map<string, JobRecord>();
+
+export function persistJob(job: Omit<JobRecord, 'createdAt'> & { createdAt?: number }) {
+  const record: JobRecord = {
+    ...job,
+    createdAt: job.createdAt ?? Date.now(),
+  };
+
+  jobs.set(record.id, record);
+}
+
+export function updateJob(jobId: string, updates: Partial<JobRecord>) {
+  const current = jobs.get(jobId);
+  if (!current) {
+    throw new Error(`Job ${jobId} not found`);
+  }
+
+  const next: JobRecord = {
+    ...current,
+    ...updates,
+  };
+
+  jobs.set(jobId, next);
+}
+
+export function retrieveJobs(): JobRecord[] {
+  return Array.from(jobs.values()).sort((a, b) => b.createdAt - a.createdAt);
+}

--- a/frontend/server/obsClient.ts
+++ b/frontend/server/obsClient.ts
@@ -1,0 +1,57 @@
+import ObsClient from 'esdk-obs-nodejs';
+
+let cachedClient: ObsClient | null = null;
+
+function getObsClient() {
+  if (cachedClient) {
+    return cachedClient;
+  }
+
+  const accessKeyId = process.env.OBS_ACCESS_KEY_ID;
+  const secretAccessKey = process.env.OBS_SECRET_ACCESS_KEY;
+  const server = process.env.OBS_ENDPOINT;
+  const bucket = process.env.OBS_BUCKET_NAME;
+
+  if (!accessKeyId || !secretAccessKey || !server || !bucket) {
+    throw new Error('OBS credentials are not fully configured');
+  }
+
+  cachedClient = new ObsClient({
+    access_key_id: accessKeyId,
+    secret_access_key: secretAccessKey,
+    server,
+  });
+
+  return cachedClient;
+}
+
+export async function uploadBufferToObs(buffer: Buffer, key: string) {
+  const client = getObsClient();
+  const bucket = process.env.OBS_BUCKET_NAME!;
+
+  await new Promise<void>((resolve, reject) => {
+    client.putObject({
+      Bucket: bucket,
+      Key: key,
+      Body: buffer,
+    }, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+export function createSignedUrl(key: string, expiresInSeconds = 3600) {
+  const client = getObsClient();
+  const bucket = process.env.OBS_BUCKET_NAME!;
+
+  return client.createSignedUrlSync({
+    Method: 'GET',
+    Bucket: bucket,
+    Key: key,
+    Expires: expiresInSeconds,
+  }).SignedUrl;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js frontend that uploads videos to OBS, dispatches CCI conversion jobs, and exposes job status APIs
- add reusable OBS helpers, in-memory job tracking, and Docker packaging for the frontend image
- implement the Python-based converter job with ffmpeg, OBS integration, callback notifications, and its own container image
- document required environment variables and build instructions for both services

## Testing
- python -m py_compile converter/main.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ab381c388323bbc9d84dfb36f30c