### PR TITLE
Ensure frontend public directory exists for Docker build

### DIFF
--- a/frontend/public/.gitkeep
+++ b/frontend/public/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder to ensure public directory exists


### PR DESCRIPTION
## Summary
- add a placeholder file so the frontend public/ directory is always created during the Docker build

## Testing
- npm run build *(fails: Type error: Could not find a declaration file for module 'esdk-obs-nodejs')*

------
https://chatgpt.com/codex/tasks/task_e_68dc1315486c832381eeaa5d9d618391