### PR TITLE
Update OBS SDK dependency version

### DIFF
--- a/converter/requirements.txt
+++ b/converter/requirements.txt
@@ -1,2 +1,2 @@
-esdk-obs-python==3.23.3
+esdk-obs-python==3.23.12
 requests==2.31.0


### PR DESCRIPTION
## Summary
- update the converter's OBS SDK dependency to a published release so Docker builds succeed

## Testing
- pip install --no-cache-dir -r requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68dc147b168483239b1b80b613ab598e