### PR TITLE
Improve job status webhook payload handling

### DIFF
--- a/frontend/pages/api/job-status.ts
+++ b/frontend/pages/api/job-status.ts
@@ -4,8 +4,67 @@ import { createSignedUrl } from '../../server/obsClient';
 
 type JobStatus = 'pending' | 'running' | 'failed' | 'completed';
 
-function isValidStatus(status: unknown): status is JobStatus {
-  return status === 'pending' || status === 'running' || status === 'failed' || status === 'completed';
+function coerceBody(payload: unknown): Record<string, unknown> {
+  if (payload && typeof payload === 'object') {
+    return payload as Record<string, unknown>;
+  }
+
+  if (typeof payload === 'string') {
+    try {
+      const parsed = JSON.parse(payload);
+      if (parsed && typeof parsed === 'object') {
+        return parsed as Record<string, unknown>;
+      }
+    } catch (error) {
+      console.error('Unable to parse job status payload', error);
+    }
+  }
+
+  return {};
+}
+
+function extractJobId(body: Record<string, unknown>): string | null {
+  const candidates = [
+    body['jobId'],
+    body['jobID'],
+    body['job_id'],
+    body['id'],
+    (body['job'] as Record<string, unknown> | undefined)?.id,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function normalizeStatus(value: unknown): JobStatus | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  const mapping: Record<string, JobStatus> = {
+    pending: 'pending',
+    queued: 'pending',
+    queue: 'pending',
+    running: 'running',
+    processing: 'running',
+    in_progress: 'running',
+    'in-progress': 'running',
+    failed: 'failed',
+    failure: 'failed',
+    error: 'failed',
+    completed: 'completed',
+    complete: 'completed',
+    succeeded: 'completed',
+    success: 'completed',
+  };
+
+  return mapping[normalized] ?? null;
 }
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<{ message: string }>) {
@@ -15,16 +74,31 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
     return;
   }
 
-  let { jobId, status, downloadUrl, errorMessage, targetKey } = req.body ?? {};
+  const body = coerceBody(req.body);
+  const jobId = extractJobId(body);
+  const status = normalizeStatus(
+    body['status'] ?? body['state'] ?? body['jobStatus'] ?? (body['job'] as Record<string, unknown> | undefined)?.status
+  );
+  let { downloadUrl, errorMessage, targetKey } = body as {
+    downloadUrl?: unknown;
+    errorMessage?: unknown;
+    targetKey?: unknown;
+  };
 
-  if (typeof jobId !== 'string' || !isValidStatus(status)) {
+  if (!jobId || !status) {
     res.status(400).json({ message: 'jobId and a valid status are required' });
     return;
   }
 
-  if (status === 'completed' && !downloadUrl && typeof targetKey === 'string') {
+  const downloadUrlString = typeof downloadUrl === 'string' ? downloadUrl : undefined;
+  const errorMessageString = typeof errorMessage === 'string' ? errorMessage : undefined;
+  const targetKeyString = typeof targetKey === 'string' ? targetKey : undefined;
+
+  let resolvedDownloadUrl = downloadUrlString;
+
+  if (status === 'completed' && !resolvedDownloadUrl && targetKeyString) {
     try {
-      downloadUrl = createSignedUrl(targetKey);
+      resolvedDownloadUrl = createSignedUrl(targetKeyString);
     } catch (error) {
       console.error(error);
     }
@@ -33,8 +107,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   try {
     updateJob(jobId, {
       status,
-      downloadUrl,
-      errorMessage,
+      downloadUrl: resolvedDownloadUrl,
+      errorMessage: errorMessageString,
     });
 
     res.status(200).json({ message: 'Job updated' });


### PR DESCRIPTION
## Summary
- make the job status API more tolerant of alternative payload shapes and casing
- normalise incoming status values and reuse target keys to build signed URLs when needed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd77a812948323bd3316eea8a4b0ca