### PR TITLE
Add detailed server-side logging to conversion job pipeline

### DIFF
--- a/frontend/pages/api/jobs.ts
+++ b/frontend/pages/api/jobs.ts
@@ -15,32 +15,55 @@ export const config = {
 type JobsResponse = ReturnType<typeof retrieveJobs>;
 
 async function parseForm(req: NextApiRequest) {
+  console.log('[api/jobs] Starting multipart form parsing');
   const form = formidable({ multiples: false });
 
   return new Promise<{ filename: string; buffer: Buffer }>((resolve, reject) => {
     form.parse(req, (err, _fields, files) => {
       if (err) {
+        console.error('[api/jobs] Form parsing failed', err);
         reject(err);
         return;
       }
 
       const file = Array.isArray(files.file) ? files.file[0] : files.file;
       if (!file || !file.filepath || !file.originalFilename) {
+        console.warn('[api/jobs] Form parsing finished without a usable file payload', {
+          receivedFile: file ? { filepath: Boolean(file.filepath), originalFilename: file.originalFilename } : null,
+        });
         reject(new Error('File upload is required'));
         return;
       }
 
       if (!file.mimetype?.startsWith('video/')) {
+        console.warn('[api/jobs] Uploaded file rejected due to unsupported mimetype', {
+          originalFilename: file.originalFilename,
+          mimetype: file.mimetype,
+        });
         reject(new Error('Only video files are supported'));
         return;
       }
 
+      console.log('[api/jobs] Upload accepted, reading file from disk', {
+        originalFilename: file.originalFilename,
+        filepath: file.filepath,
+        mimetype: file.mimetype,
+        size: file.size,
+      });
+
       readFile(file.filepath)
         .then(async (data) => {
           await unlink(file.filepath).catch(() => undefined);
+          console.log('[api/jobs] File read completed, temporary file removed', {
+            originalFilename: file.originalFilename,
+            bytesRead: data.length,
+          });
           resolve({ filename: file.originalFilename!, buffer: data });
         })
-        .catch(reject);
+        .catch((readError) => {
+          console.error('[api/jobs] Failed to read uploaded file', readError);
+          reject(readError);
+        });
     });
   });
 }
@@ -49,8 +72,13 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<JobsResponse | { message: string }>
 ) {
+  console.log('[api/jobs] Incoming request', {
+    method: req.method,
+    contentType: req.headers['content-type'],
+  });
   if (req.method === 'GET') {
     const jobs = retrieveJobs();
+    console.log('[api/jobs] Returning job list', { count: jobs.length });
     res.status(200).json(jobs);
     return;
   }
@@ -70,7 +98,17 @@ export default async function handler(
     const sourceKey = `${process.env.OBS_UPLOAD_PREFIX ?? 'uploads/'}${timestamp}-${filename}`;
     const targetKey = `${process.env.OBS_OUTPUT_PREFIX ?? 'gifs/'}${timestamp}-${filename.replace(/\.[^.]+$/, '')}.gif`;
 
+    console.log('[api/jobs] Upload parsed successfully', {
+      filename,
+      timestamp,
+      sourceKey,
+      targetKey,
+      bufferSize: buffer.length,
+    });
+
     await uploadBufferToObs(buffer, sourceKey);
+
+    console.log('[api/jobs] Upload stored in OBS', { sourceKey });
 
     jobId = randomUUID();
 
@@ -82,13 +120,18 @@ export default async function handler(
       createdAt: timestamp,
     });
 
+    console.log('[api/jobs] Job persisted locally', { jobId, status: 'pending' });
+
     await dispatchConversionJob({
       jobId,
       sourceKey,
       targetKey,
     });
 
+    console.log('[api/jobs] Conversion job dispatched', { jobId, sourceKey, targetKey });
+
     res.status(201).json(retrieveJobs());
+    console.log('[api/jobs] Response sent for job creation request', { jobId });
   } catch (error) {
     console.error(error);
     const message = error instanceof Error ? error.message : 'Unable to create conversion job';
@@ -96,11 +139,13 @@ export default async function handler(
     if (jobId) {
       try {
         updateJob(jobId, { status: 'failed', errorMessage: message });
+        console.warn('[api/jobs] Job marked as failed after error', { jobId, message });
       } catch (storeError) {
         console.error(storeError);
       }
     }
 
     res.status(500).json({ message });
+    console.error('[api/jobs] Job creation request failed', { jobId, message });
   }
 }

--- a/frontend/server/jobDispatcher.ts
+++ b/frontend/server/jobDispatcher.ts
@@ -12,6 +12,14 @@ const CALLBACK_PATH = '/api/job-status';
 export async function dispatchConversionJob(options: DispatchOptions) {
   const callbackUrl = new URL(CALLBACK_PATH, process.env.PUBLIC_BASE_URL ?? 'http://localhost:3000').toString();
 
+  console.log('[jobDispatcher] Preparing to dispatch job', {
+    jobId: options.jobId,
+    sourceKey: options.sourceKey,
+    targetKey: options.targetKey,
+    callbackUrl,
+    publicBaseUrlConfigured: Boolean(process.env.PUBLIC_BASE_URL),
+  });
+
   try {
     const result = await createCciJob({
       jobId: options.jobId,
@@ -20,12 +28,29 @@ export async function dispatchConversionJob(options: DispatchOptions) {
       callbackUrl,
     });
 
+    console.log('[jobDispatcher] CCI job creation succeeded', {
+      jobId: options.jobId,
+      cciJobName: result.jobName,
+    });
+
     updateJob(options.jobId, { status: 'running', cciJobName: result.jobName });
+    console.log('[jobDispatcher] Job status updated to running', {
+      jobId: options.jobId,
+      cciJobName: result.jobName,
+    });
   } catch (error) {
     if (isMissingConfiguration(error)) {
+      console.error('[jobDispatcher] Missing configuration detected while creating CCI job', {
+        jobId: options.jobId,
+        message: error.message,
+      });
       throw new Error(`CCI job creation failed due to missing configuration: ${error.message}`);
     }
 
+    console.error('[jobDispatcher] Unexpected error while creating CCI job', {
+      jobId: options.jobId,
+      error,
+    });
     throw error instanceof Error ? error : new Error('Failed to create CCI job');
   }
 }

--- a/frontend/server/jobStore.ts
+++ b/frontend/server/jobStore.ts
@@ -18,11 +18,19 @@ export function persistJob(job: Omit<JobRecord, 'createdAt'> & { createdAt?: num
   };
 
   jobs.set(record.id, record);
+  console.log('[jobStore] Persisted job', {
+    jobId: record.id,
+    status: record.status,
+    sourceKey: record.sourceKey,
+    targetKey: record.targetKey,
+    createdAt: record.createdAt,
+  });
 }
 
 export function updateJob(jobId: string, updates: Partial<JobRecord>) {
   const current = jobs.get(jobId);
   if (!current) {
+    console.warn('[jobStore] Attempted to update unknown job', { jobId, updates });
     throw new Error(`Job ${jobId} not found`);
   }
 
@@ -32,8 +40,17 @@ export function updateJob(jobId: string, updates: Partial<JobRecord>) {
   };
 
   jobs.set(jobId, next);
+  console.log('[jobStore] Updated job', {
+    jobId: next.id,
+    previousStatus: current.status,
+    nextStatus: next.status,
+    hasDownloadUrl: Boolean(next.downloadUrl),
+    hasErrorMessage: Boolean(next.errorMessage),
+  });
 }
 
 export function retrieveJobs(): JobRecord[] {
-  return Array.from(jobs.values()).sort((a, b) => b.createdAt - a.createdAt);
+  const sorted = Array.from(jobs.values()).sort((a, b) => b.createdAt - a.createdAt);
+  console.log('[jobStore] Retrieved job collection', { count: sorted.length });
+  return sorted;
 }


### PR DESCRIPTION
## Summary
- add extensive logging to the job creation API to trace uploads and dispatcher flow
- enrich CCI client, job dispatcher, job store, and OBS helpers with structured debug messages
- log webhook activity and outcomes in the job-status API for clearer callback diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deaca103ac8323b177161c5692276f