### PR TITLE
Handle missing configuration for job creation

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -82,7 +82,18 @@ export default function Home() {
       });
 
       if (!response.ok) {
-        const message = await response.text();
+        const rawMessage = await response.text();
+        let parsedMessage: string | null = null;
+        try {
+          const parsed = JSON.parse(rawMessage);
+          if (parsed && typeof parsed === 'object' && 'message' in parsed) {
+            parsedMessage = String(parsed.message);
+          }
+        } catch (_error) {
+          // Ignore JSON parse errors and fall back to using the raw message.
+        }
+
+        const message = parsedMessage || (rawMessage && !rawMessage.startsWith('<') ? rawMessage : null);
         throw new Error(message || 'Unable to create conversion job');
       }
 


### PR DESCRIPTION
## Summary
- surface missing OBS/CCI configuration earlier in the /api/jobs handler and respond with a clear 503 error
- improve the upload form error handling so JSON error messages are displayed instead of raw HTML

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68debf7700e0832391296c8e0727631c