### PR TITLE
Poll CCI job status for failures and fix ffmpeg filter

### DIFF
--- a/frontend/pages/api/jobs.ts
+++ b/frontend/pages/api/jobs.ts
@@ -5,6 +5,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { persistJob, retrieveJobs, updateJob } from '../../server/jobStore';
 import { dispatchConversionJob } from '../../server/jobDispatcher';
 import { uploadBufferToObs } from '../../server/obsClient';
+import { reconcileJobsWithCluster } from '../../server/jobStatusSynchronizer';
 
 export const config = {
   api: {
@@ -107,6 +108,8 @@ export default async function handler(
     contentType: req.headers['content-type'],
   });
   if (req.method === 'GET') {
+    const snapshot = retrieveJobs();
+    await reconcileJobsWithCluster(snapshot);
     const jobs = retrieveJobs();
     console.log('[api/jobs] Returning job list', { count: jobs.length });
     res.status(200).json(jobs);

--- a/frontend/server/cciClient.ts
+++ b/frontend/server/cciClient.ts
@@ -87,6 +87,164 @@ function collectJobEnv(params: CreateJobParams) {
   return envVars;
 }
 
+type CciClientContext = {
+  client: HcClient;
+  namespace: string;
+  projectId: string;
+  baseEndpoint: string;
+  userAgent?: string;
+};
+
+let cachedClientContext: CciClientContext | null = null;
+
+function getCciClientContext(): CciClientContext {
+  if (cachedClientContext) {
+    return cachedClientContext;
+  }
+
+  const accessKey = requireEnvWithFallback('HUAWEI_CLOUD_AK', ['OBS_ACCESS_KEY_ID']);
+  const secretKey = requireEnvWithFallback('HUAWEI_CLOUD_SK', ['OBS_SECRET_ACCESS_KEY']);
+  const projectId = requireEnv('HUAWEI_CLOUD_PROJECT_ID');
+  const namespace = process.env.CCI_NAMESPACE ?? 'default';
+  const region = process.env.CCI_REGION;
+  const baseEndpoint = process.env.CCI_API_ENDPOINT ?? (region ? `https://cci.${region}.myhuaweicloud.com` : undefined);
+
+  if (!baseEndpoint) {
+    throw new MissingConfigurationError('CCI_API_ENDPOINT or CCI_REGION must be configured');
+  }
+
+  const credentials = new BasicCredentials()
+    .withAk(accessKey)
+    .withSk(secretKey)
+    .withProjectId(projectId);
+
+  const client = new ClientBuilder<HcClient>((hcClient) => hcClient)
+    .withCredential(credentials)
+    .withEndpoint(baseEndpoint)
+    .build();
+
+  cachedClientContext = {
+    client,
+    namespace,
+    projectId,
+    baseEndpoint,
+    userAgent: process.env.CCI_USER_AGENT,
+  };
+
+  console.log('[cciClient] Initialized Huawei Cloud CCI client', {
+    namespace,
+    baseEndpoint,
+    userAgentConfigured: Boolean(cachedClientContext.userAgent),
+  });
+
+  return cachedClientContext;
+}
+
+type NumericLike = number | string | undefined | null;
+
+function coerceNumber(value: NumericLike): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+export type ClusterJobStatus = {
+  phase: 'pending' | 'running' | 'failed' | 'completed';
+  reason?: string;
+  message?: string;
+};
+
+function normalizeCondition(condition: unknown) {
+  if (!condition || typeof condition !== 'object') {
+    return null;
+  }
+
+  const entry = condition as Record<string, unknown>;
+  const type = coerceString(entry['type']);
+  if (!type) {
+    return null;
+  }
+
+  const status = coerceString(entry['status']);
+  const reason = coerceString(entry['reason']);
+  const message = coerceString(entry['message']);
+
+  return { type: type.toLowerCase(), status: status?.toLowerCase(), reason, message };
+}
+
+export async function fetchCciJobStatus(jobName: string): Promise<ClusterJobStatus | null> {
+  const context = getCciClientContext();
+  const path = `/apis/batch/v1/namespaces/${encodeURIComponent(context.namespace)}/jobs/${encodeURIComponent(jobName)}`;
+
+  const response = await context.client.sendRequest<Record<string, unknown>>({
+    method: 'GET',
+    url: path,
+    contentType: 'application/json',
+    headers: {
+      'X-Project-Id': context.projectId,
+      ...(context.userAgent ? { 'User-Agent': context.userAgent } : {}),
+    },
+    queryParams: {},
+    pathParams: {},
+  });
+
+  const payload = (response as unknown as { data?: Record<string, unknown> }).data ?? {};
+  const status = payload['status'];
+
+  if (!status || typeof status !== 'object') {
+    return null;
+  }
+
+  const statusBody = status as Record<string, unknown>;
+  const succeededCount = coerceNumber(statusBody['succeeded']) ?? 0;
+  const failedCount = coerceNumber(statusBody['failed']) ?? 0;
+  const activeCount = coerceNumber(statusBody['active']) ?? 0;
+
+  const conditionsRaw = Array.isArray(statusBody['conditions']) ? statusBody['conditions'] : [];
+  const conditions = conditionsRaw
+    .map((condition) => normalizeCondition(condition))
+    .filter(Boolean) as Array<{ type: string; status?: string; reason?: string; message?: string }>;
+
+  const findCondition = (type: string) =>
+    conditions.find((condition) => condition.type === type && condition.status === 'true');
+
+  const completeCondition = findCondition('complete');
+  if (succeededCount > 0 || completeCondition) {
+    return { phase: 'completed' };
+  }
+
+  const failedCondition = findCondition('failed');
+  if (failedCount > 0 || failedCondition) {
+    const reason = failedCondition?.reason ?? coerceString(statusBody['reason']);
+    const message = failedCondition?.message ?? coerceString(statusBody['message']);
+
+    return {
+      phase: 'failed',
+      reason,
+      message,
+    };
+  }
+
+  if (activeCount > 0) {
+    return { phase: 'running' };
+  }
+
+  return { phase: 'pending' };
+}
+
 export async function createCciJob(params: CreateJobParams): Promise<CreateJobResult> {
   console.log('[cciClient] Creating CCI job request', {
     jobId: params.jobId,
@@ -102,16 +260,6 @@ export async function createCciJob(params: CreateJobParams): Promise<CreateJobRe
       }
     })(),
   });
-  const accessKey = requireEnvWithFallback('HUAWEI_CLOUD_AK', ['OBS_ACCESS_KEY_ID']);
-  const secretKey = requireEnvWithFallback('HUAWEI_CLOUD_SK', ['OBS_SECRET_ACCESS_KEY']);
-  const projectId = requireEnv('HUAWEI_CLOUD_PROJECT_ID');
-  const namespace = process.env.CCI_NAMESPACE ?? 'default';
-  const region = process.env.CCI_REGION;
-  const baseEndpoint = process.env.CCI_API_ENDPOINT ?? (region ? `https://cci.${region}.myhuaweicloud.com` : undefined);
-  if (!baseEndpoint) {
-    throw new MissingConfigurationError('CCI_API_ENDPOINT or CCI_REGION must be configured');
-  }
-
   const image = requireEnv('CCI_JOB_IMAGE');
   const cpu = process.env.CCI_JOB_CPU ?? '1';
   const memory = process.env.CCI_JOB_MEMORY ?? '2Gi';
@@ -122,13 +270,15 @@ export async function createCciJob(params: CreateJobParams): Promise<CreateJobRe
   const serviceAccount = process.env.CCI_SERVICE_ACCOUNT_NAME;
   const imagePullSecret = process.env.CCI_IMAGE_PULL_SECRET;
 
+  const context = getCciClientContext();
+  const namespace = context.namespace;
+
   const jobName = buildJobName(params.jobId);
   console.log('[cciClient] Converter job payload prepared', {
     jobId: params.jobId,
     jobName,
     namespace,
-    region,
-    baseEndpoint,
+    baseEndpoint: context.baseEndpoint,
     image,
     cpu,
     memory,
@@ -189,32 +339,21 @@ export async function createCciJob(params: CreateJobParams): Promise<CreateJobRe
     (payload.spec as any).ttlSecondsAfterFinished = ttlSecondsAfterFinished;
   }
 
-  const credentials = new BasicCredentials()
-    .withAk(accessKey)
-    .withSk(secretKey)
-    .withProjectId(projectId);
-
-  const client = new ClientBuilder<HcClient>((hcClient) => hcClient)
-    .withCredential(credentials)
-    .withEndpoint(baseEndpoint)
-    .build();
-
-  const userAgent = process.env.CCI_USER_AGENT;
   const path = `/apis/batch/v1/namespaces/${encodeURIComponent(namespace)}/jobs`;
 
   try {
     console.log('[cciClient] Sending job creation request to Huawei Cloud CCI', {
       jobId: params.jobId,
       path,
-      userAgentConfigured: Boolean(userAgent),
+      userAgentConfigured: Boolean(context.userAgent),
     });
-    await client.sendRequest({
+    await context.client.sendRequest({
       method: 'POST',
       url: path,
       contentType: 'application/json',
       headers: {
-        'X-Project-Id': projectId,
-        ...(userAgent ? { 'User-Agent': userAgent } : {}),
+        'X-Project-Id': context.projectId,
+        ...(context.userAgent ? { 'User-Agent': context.userAgent } : {}),
       },
       queryParams: {},
       pathParams: {},

--- a/frontend/server/jobStatusSynchronizer.ts
+++ b/frontend/server/jobStatusSynchronizer.ts
@@ -1,0 +1,71 @@
+import { fetchCciJobStatus, type ClusterJobStatus } from './cciClient';
+import { createSignedUrl } from './obsClient';
+import type { JobRecord } from './jobStore';
+import { updateJob } from './jobStore';
+
+const TERMINAL_STATUSES = new Set<JobRecord['status']>(['failed', 'completed']);
+
+function buildFailureMessage(status: ClusterJobStatus): string | undefined {
+  const parts = [status.reason, status.message].filter((part) => typeof part === 'string' && part.trim()) as string[];
+  if (parts.length === 0) {
+    return undefined;
+  }
+
+  const combined = parts.join(': ');
+  return combined.length > 500 ? `${combined.slice(0, 497)}…` : combined;
+}
+
+export async function reconcileJobsWithCluster(jobs: JobRecord[]): Promise<void> {
+  const candidates = jobs.filter((job) => job.cciJobName && !TERMINAL_STATUSES.has(job.status));
+  if (candidates.length === 0) {
+    return;
+  }
+
+  await Promise.all(
+    candidates.map(async (job) => {
+      const jobName = job.cciJobName!;
+      try {
+        const status = await fetchCciJobStatus(jobName);
+        if (!status || status.phase === 'pending' || status.phase === 'running') {
+          return;
+        }
+
+        const updates: Partial<JobRecord> = { status: status.phase };
+
+        if (status.phase === 'failed') {
+          const failureMessage = buildFailureMessage(status);
+          if (failureMessage) {
+            updates.errorMessage = failureMessage;
+          }
+        } else if (status.phase === 'completed' && !job.downloadUrl) {
+          try {
+            updates.downloadUrl = createSignedUrl(job.targetKey);
+          } catch (error) {
+            console.error('[jobStatusSynchronizer] Unable to generate signed OBS URL', {
+              jobId: job.id,
+              jobName,
+              targetKey: job.targetKey,
+              error,
+            });
+          }
+        }
+
+        updateJob(job.id, updates);
+        console.log('[jobStatusSynchronizer] Job state reconciled with cluster', {
+          jobId: job.id,
+          jobName,
+          resolvedPhase: status.phase,
+          appliedErrorMessage: Boolean(updates.errorMessage),
+          appliedDownloadUrl: Boolean(updates.downloadUrl),
+        });
+      } catch (error) {
+        console.error('[jobStatusSynchronizer] Failed to synchronize job with cluster', {
+          jobId: job.id,
+          jobName,
+          error,
+        });
+      }
+    })
+  );
+}
+


### PR DESCRIPTION
## Summary
- switch the converter to use a single filter_complex palette pipeline so ffmpeg no longer fails when writing GIFs
- cache the Huawei Cloud CCI client and expose helpers to inspect job status information
- reconcile stored job records with cluster status during job listing so failed runs are marked and download links attached automatically

## Testing
- python3 -m compileall converter
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3edb29d74832393bebed84c2fdc8f