### PR TITLE
Fix ffmpeg palette generation filter

### DIFF
--- a/converter/main.py
+++ b/converter/main.py
@@ -53,7 +53,7 @@ def convert_to_gif(source: str, target: str) -> None:
                 "-i",
                 str(source_path),
                 "-vf",
-                "fps=10,scale=480:-1:flags=lanczos",
+                "fps=10,scale=480:-1:flags=lanczos,palettegen",
                 str(palette_path),
             ],
             check=False,


### PR DESCRIPTION
## Summary
- ensure the palette generation ffmpeg command applies the palettegen filter so palette files are produced

## Testing
- python - <<'PY'
from pathlib import Path
import sys
sys.path.append('videotogif')
from converter.main import convert_to_gif

source = Path('videotogif/test.mp4').resolve()
target = Path('videotogif/out.gif').resolve()
convert_to_gif(str(source), str(target))
print(target.exists(), target.stat().st_size if target.exists() else 0)
PY *(fails: ffmpeg not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4120afd308323a8f30a928a11b190