### PR TITLE
Fix OBS uploads by streaming buffers

### DIFF
--- a/frontend/server/obsClient.ts
+++ b/frontend/server/obsClient.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'crypto';
+import { Readable } from 'stream';
 import ObsClient from 'esdk-obs-nodejs';
 
 let cachedClient: ObsClient | null = null;
@@ -50,10 +51,11 @@ export async function uploadBufferToObs(buffer: Buffer, key: string) {
   });
 
   await new Promise<void>((resolve, reject) => {
+    const bodyStream = Readable.from(buffer);
     client.putObject({
       Bucket: bucket,
       Key: key,
-      Body: buffer,
+      Body: bodyStream,
       ContentMD5: contentMd5Base64,
     }, (error, result) => {
       if (error) {


### PR DESCRIPTION
## Summary
- stream uploaded buffers into the OBS SDK rather than passing them as raw buffers to prevent implicit UTF-8 conversion
- keep the existing checksum validation while relying on a Readable stream for the upload body

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e540bf12c4832399e814191a16eb9d